### PR TITLE
Postbuildfailurefix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/serviceFabric/ServiceFabricPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/serviceFabric/ServiceFabricPublisher.java
@@ -24,7 +24,6 @@ import org.kohsuke.stapler.QueryParameter;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.lang.Throwable;
 
 import org.jenkinsci.plugins.serviceFabric.ServiceFabricCommands.SFCommandBuilder;
 

--- a/src/main/java/org/jenkinsci/plugins/serviceFabric/ServiceFabricPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/serviceFabric/ServiceFabricPublisher.java
@@ -24,6 +24,7 @@ import org.kohsuke.stapler.QueryParameter;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.lang.Throwable;
 
 import org.jenkinsci.plugins.serviceFabric.ServiceFabricCommands.SFCommandBuilder;
 
@@ -135,7 +136,7 @@ public class ServiceFabricPublisher extends Recorder {
     // }
 
     @Override
-    public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
+    public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener){
 
 
         // use the parameters to construct the commands
@@ -143,9 +144,14 @@ public class ServiceFabricPublisher extends Recorder {
         String commandString = commandBuilder.buildCommands(); 
 
         Shell command = new Shell(commandString);
-
+        
         try{
-            command.perform(build, launcher, listener);
+            boolean status = command.perform(build, launcher, listener);
+            
+            if (status == false)
+            {
+            	return false;
+            }
         }catch(InterruptedException e){
             return false;
         }

--- a/src/main/java/org/jenkinsci/plugins/serviceFabric/ServiceFabricPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/serviceFabric/ServiceFabricPublisher.java
@@ -147,9 +147,8 @@ public class ServiceFabricPublisher extends Recorder {
         try{
             boolean status = command.perform(build, launcher, listener);
             
-            if (status == false)
-            {
-            	return false;
+            if (status == false){
+           	    return false;
             }
         }catch(InterruptedException e){
             return false;


### PR DESCRIPTION
**This is the case how the console output look like before:**

Started by user Patchigolla V S S Rahul
Building in workspace /var/jenkins_home/workspace/MyPipeline
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/rapatchi/SFJenkins.git # timeout=10
Fetching upstream changes from https://github.com/rapatchi/SFJenkins.git
 > git --version # timeout=10
 > git fetch --tags --progress https://github.com/rapatchi/SFJenkins.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse refs/remotes/origin/master^{commit} # timeout=10
 > git rev-parse refs/remotes/origin/origin/master^{commit} # timeout=10
Checking out Revision 832826a13a2ef658ee075b0e859a2bdcf812b702 (refs/remotes/origin/master)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 832826a13a2ef658ee075b0e859a2bdcf812b702
Commit message: "Made changes for to support new SF Jars"
 > git rev-list 832826a13a2ef658ee075b0e859a2bdcf812b702 # timeout=10
[Gradle] - Launching build.
[MyActor] $ gradle
:clean
:MyActorService:clean
:MyActorServiceInterface:clean
:MyActorServiceTestClient:clean
Cleaning
:compileJava UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:jar
:MyActorService:explodeDeps UP-TO-DATE
:MyActorServiceInterface:explodeDeps UP-TO-DATE
:MyActorServiceInterface:compileJava
:MyActorServiceInterface:processResources UP-TO-DATE
:MyActorServiceInterface:classes
:MyActorServiceInterface:jar UP-TO-DATE
:MyActorService:compileJava
:MyActorService:processResources UP-TO-DATE
:MyActorService:classes
:MyActorService:jar
:MyActorServiceTestClient:compileJava
:MyActorServiceTestClient:processResources UP-TO-DATE
:MyActorServiceTestClient:classes
:MyActorServiceTestClient:jar
:MyActorService:copyDeps
:MyActorServiceTestClient:copyDeps

BUILD SUCCESSFUL

Total time: 3.214 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.10/userguide/gradle_daemon.html
Build step 'Invoke Gradle script' changed build result to SUCCESS
[MyPipeline] $ /bin/sh -xe /tmp/jenkins4737725272398912275.sh
+ sfctl cluster select --endpoint http://rapatchlinux1.southindia.cloudapp.azure.com:19080
ERROR: Error occurred in request., ConnectionError: HTTPConnectionPool(host='rapatchlinux1.southindia.cloudapp.azure.com', port=19080): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f8f7bc93390>: Failed to establish a new connection: [Errno -2] Name or service not known',))
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/knack/cli.py", line 125, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/local/lib/python2.7/dist-packages/knack/invocation.py", line 85, in execute
    cmd_result = parsed_args.func(params)
  File "/usr/local/lib/python2.7/dist-packages/knack/commands.py", line 67, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/knack/commands.py", line 123, in _command_handler
    result = op(client, **command_args) if client else op(**command_args)
  File "/usr/local/lib/python2.7/dist-packages/sfctl/custom_cluster.py", line 95, in select
    rest_client.send(rest_client.get('/')).raise_for_status()
  File "/usr/local/lib/python2.7/dist-packages/msrest/service_client.py", line 225, in send
    raise_with_traceback(ClientRequestError, msg, err)
  File "/usr/local/lib/python2.7/dist-packages/msrest/exceptions.py", line 48, in raise_with_traceback
    raise error
ClientRequestError: Error occurred in request., ConnectionError: HTTPConnectionPool(host='rapatchlinux1.southindia.cloudapp.azure.com', port=19080): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f8f7bc93390>: Failed to establish a new connection: [Errno -2] Name or service not known',))
Finished: SUCCESS **(This is the place where you will find the difference)**

**This is how the console looks like now:**

Started by user Patchigolla V S S Rahul
Building in workspace /var/jenkins_home/workspace/MyPipeline
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/rapatchi/SFJenkins.git # timeout=10
Fetching upstream changes from https://github.com/rapatchi/SFJenkins.git
 > git --version # timeout=10
 > git fetch --tags --progress https://github.com/rapatchi/SFJenkins.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse refs/remotes/origin/master^{commit} # timeout=10
 > git rev-parse refs/remotes/origin/origin/master^{commit} # timeout=10
Checking out Revision 832826a13a2ef658ee075b0e859a2bdcf812b702 (refs/remotes/origin/master)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 832826a13a2ef658ee075b0e859a2bdcf812b702
Commit message: "Made changes for to support new SF Jars"
 > git rev-list 832826a13a2ef658ee075b0e859a2bdcf812b702 # timeout=10
[Gradle] - Launching build.
[MyActor] $ gradle
:clean
:MyActorService:clean
:MyActorServiceInterface:clean
:MyActorServiceTestClient:clean
Cleaning
:compileJava UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:jar
:MyActorService:explodeDeps UP-TO-DATE
:MyActorServiceInterface:explodeDeps UP-TO-DATE
:MyActorServiceInterface:compileJava
:MyActorServiceInterface:processResources UP-TO-DATE
:MyActorServiceInterface:classes
:MyActorServiceInterface:jar UP-TO-DATE
:MyActorService:compileJava
:MyActorService:processResources UP-TO-DATE
:MyActorService:classes
:MyActorService:jar UP-TO-DATE
:MyActorServiceTestClient:compileJava
:MyActorServiceTestClient:processResources UP-TO-DATE
:MyActorServiceTestClient:classes
:MyActorServiceTestClient:jar UP-TO-DATE
:MyActorService:copyDeps
:MyActorServiceTestClient:copyDeps

BUILD SUCCESSFUL

Total time: 3.22 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.10/userguide/gradle_daemon.html
Build step 'Invoke Gradle script' changed build result to SUCCESS
[MyPipeline] $ /bin/sh -xe /tmp/jenkins7077011063635724566.sh
+ sfctl cluster select --endpoint http://rapatchlinux1.southindia.cloudapp.azure.com:19080
ERROR: Error occurred in request., ConnectionError: HTTPConnectionPool(host='rapatchlinux1.southindia.cloudapp.azure.com', port=19080): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fefab40f390>: Failed to establish a new connection: [Errno -2] Name or service not known',))
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/knack/cli.py", line 125, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/local/lib/python2.7/dist-packages/knack/invocation.py", line 85, in execute
    cmd_result = parsed_args.func(params)
  File "/usr/local/lib/python2.7/dist-packages/knack/commands.py", line 67, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/knack/commands.py", line 123, in _command_handler
    result = op(client, **command_args) if client else op(**command_args)
  File "/usr/local/lib/python2.7/dist-packages/sfctl/custom_cluster.py", line 95, in select
    rest_client.send(rest_client.get('/')).raise_for_status()
  File "/usr/local/lib/python2.7/dist-packages/msrest/service_client.py", line 225, in send
    raise_with_traceback(ClientRequestError, msg, err)
  File "/usr/local/lib/python2.7/dist-packages/msrest/exceptions.py", line 48, in raise_with_traceback
    raise error
ClientRequestError: Error occurred in request., ConnectionError: HTTPConnectionPool(host='rapatchlinux1.southindia.cloudapp.azure.com', port=19080): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fefab40f390>: Failed to establish a new connection: [Errno -2] Name or service not known',))
Build step 'Deploy Service Fabric Project' marked build as failure
Finished: FAILURE