### PR TITLE
Use scoped Azure credentials lookup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <jenkins.version>1.651.3</jenkins.version>
         <java.level>7</java.level>
 
-        <azure-commons.version>0.2.4</azure-commons.version>
-        <azure-credentials.version>1.4.0</azure-credentials.version>
+        <azure-commons.version>0.2.5</azure-commons.version>
+        <azure-credentials.version>1.6.0</azure-credentials.version>
         <azure-sdk.version>1.5.1</azure-sdk.version>
     </properties>
 

--- a/src/main/java/com/microsoft/jenkins/servicefabric/ServiceFabricPublishStep.java
+++ b/src/main/java/com/microsoft/jenkins/servicefabric/ServiceFabricPublishStep.java
@@ -134,7 +134,7 @@ public class ServiceFabricPublishStep extends Step implements Serializable {
 
         String cfgType = getConfigureType();
         if (Constants.CONFIGURE_TYPE_SELECT.equals(cfgType)) {
-            Azure azure = AzureHelper.buildClient(azureCredentialsId);
+            Azure azure = AzureHelper.buildClient(run.getParent(), azureCredentialsId);
             AzureServiceFabricPlugin.sendEvent("DeployAzure",
                     Constants.AI_RUN, buildId,
                     "Subscription", AppInsightsUtils.hash(azure.subscriptionId()),
@@ -357,7 +357,8 @@ public class ServiceFabricPublishStep extends Step implements Serializable {
             return model;
         }
 
-        public ListBoxModel doFillResourceGroupItems(@QueryParameter String azureCredentialsId) {
+        public ListBoxModel doFillResourceGroupItems(@AncestorInPath Item owner,
+                                                     @QueryParameter String azureCredentialsId) {
             ListBoxModel model = new ListBoxModel();
             model.add("");
 
@@ -366,7 +367,7 @@ public class ServiceFabricPublishStep extends Step implements Serializable {
             }
 
             try {
-                Azure azure = AzureHelper.buildClient(azureCredentialsId);
+                Azure azure = AzureHelper.buildClient(owner, azureCredentialsId);
                 for (ResourceGroup resourceGroup : azure.resourceGroups().list()) {
                     model.add(resourceGroup.name());
                 }
@@ -377,7 +378,8 @@ public class ServiceFabricPublishStep extends Step implements Serializable {
             return model;
         }
 
-        public ListBoxModel doFillServiceFabricItems(@QueryParameter String azureCredentialsId,
+        public ListBoxModel doFillServiceFabricItems(@AncestorInPath Item owner,
+                                                     @QueryParameter String azureCredentialsId,
                                                      @QueryParameter String resourceGroup) {
             ListBoxModel model = new ListBoxModel();
             model.add("");
@@ -387,7 +389,7 @@ public class ServiceFabricPublishStep extends Step implements Serializable {
             }
 
             try {
-                Azure azure = AzureHelper.buildClient(azureCredentialsId);
+                Azure azure = AzureHelper.buildClient(owner, azureCredentialsId);
                 // TODO: Use ServiceFabric related API when the ServiceFabric Java SDK is GA
                 PagedList<GenericResource> resources =
                         azure.genericResources().listByResourceGroup(resourceGroup);

--- a/src/main/java/com/microsoft/jenkins/servicefabric/util/AzureHelper.java
+++ b/src/main/java/com/microsoft/jenkins/servicefabric/util/AzureHelper.java
@@ -12,18 +12,20 @@ import com.microsoft.azure.util.AzureCredentialUtil;
 import com.microsoft.jenkins.azurecommons.core.AzureClientFactory;
 import com.microsoft.jenkins.azurecommons.core.credentials.TokenCredentialData;
 import com.microsoft.jenkins.servicefabric.AzureServiceFabricPlugin;
+import hudson.model.Item;
 
 public final class AzureHelper {
-    public static TokenCredentialData getToken(String credentialsId) {
-        AzureBaseCredentials credentials = AzureCredentialUtil.getCredential2(credentialsId);
+    public static TokenCredentialData getToken(Item owner, String credentialsId) {
+        AzureBaseCredentials credentials = AzureCredentialUtil.getCredential(owner, credentialsId);
         if (credentials == null) {
-            throw new IllegalStateException("Cannot find credentials with ID: " + credentialsId);
+            throw new IllegalStateException(
+                    String.format("Can't find credential in scope %s with id: %s", owner, credentialsId));
         }
         return TokenCredentialData.deserialize(credentials.serializeToTokenData());
     }
 
-    public static Azure buildClient(String credentialsId) {
-        TokenCredentialData token = getToken(credentialsId);
+    public static Azure buildClient(Item owner, String credentialsId) {
+        TokenCredentialData token = getToken(owner, credentialsId);
         return buildClient(token);
     }
 


### PR DESCRIPTION
In the original implementation, we lookup the Azure credentials in the Jenkins top level credentials storage, which will fail if the user organizes their jobs and credentials with [Folders](https://plugins.jenkins.io/cloudbees-folder) plugin.

This change fixes this issue. Now the credentials lookup is scope aware.

Related issue:
https://github.com/jenkinsci/azure-credentials-plugin/issues/25
https://github.com/jenkinsci/kubernetes-cd-plugin/issues/19
