### PR TITLE
Bug fix when the folder structure does not have two forward slashes

### DIFF
--- a/src/main/java/com/microsoft/jenkins/servicefabric/command/SFCommandBuilder.java
+++ b/src/main/java/com/microsoft/jenkins/servicefabric/command/SFCommandBuilder.java
@@ -95,7 +95,13 @@ public class SFCommandBuilder {
         // Getting application path from the appilcation-manifest path input in
         // Jenkins portal
         String tmpString = manifestPath.substring(0, manifestPath.lastIndexOf('/', manifestPath.length() - 1));
-        String applicationPath = tmpString.substring(0, tmpString.lastIndexOf('/', tmpString.length() - 1));
+        String applicationPath;
+        if(tmpString.lastIndexOf('/', tmpString.length() - 1) != -1) {
+            applicationPath = tmpString.substring(0, tmpString.lastIndexOf('/', tmpString.length() - 1));
+        }
+        else {
+            applicationPath = "..";
+        }
         outputCommand += "&& cd " + applicationPath;
 
         // add on the different commands: copy -> register -> create

--- a/src/main/java/com/microsoft/jenkins/servicefabric/command/SFCommandBuilder.java
+++ b/src/main/java/com/microsoft/jenkins/servicefabric/command/SFCommandBuilder.java
@@ -96,10 +96,9 @@ public class SFCommandBuilder {
         // Jenkins portal
         String tmpString = manifestPath.substring(0, manifestPath.lastIndexOf('/', manifestPath.length() - 1));
         String applicationPath;
-        if(tmpString.lastIndexOf('/', tmpString.length() - 1) != -1) {
+        if (tmpString.lastIndexOf('/', tmpString.length() - 1) != -1) {
             applicationPath = tmpString.substring(0, tmpString.lastIndexOf('/', tmpString.length() - 1));
-        }
-        else {
+        } else {
             applicationPath = "..";
         }
         outputCommand += "&& cd " + applicationPath;


### PR DESCRIPTION
This change is to fix the folder supported folder structure accepted by Jenkins plugin:

Before: 
The path the application manifest needs to have definitely have two slashes. 
For Example,
/DemoApp/DemoApp/ApplicationManifest.xml (works)
/DemoApp/ApplicationManifest.xml (fails)

After: 
Both of the above mentioned folder structures now work.

