### PR TITLE
Add mask class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
                     <maskClasses>
                         com.microsoft.jenkins.azurecommons.core.
                         com.google.common.
+                        com.nimbusds.
 
                         com.microsoft.azure.AzureAsyncOperation
                         com.microsoft.azure.AzureClient


### PR DESCRIPTION
In the configuration UI, when fetch the resource groups, it will throw error like:

```
Failed to load resource groups: java.io.IOException: java.lang.NoSuchMethodError: com.nimbusds.oauth2.sdk.AccessTokenResponse.<init>(Lcom/nimbusds/oauth2/sdk/token/AccessToken;Lcom/nimbusds/oauth2/sdk/token/RefreshToken;Ljava/util/Map;)V
```

Mask these classes as well will fix this.